### PR TITLE
Streaming Datagrid

### DIFF
--- a/examples/Streaming.ipynb
+++ b/examples/Streaming.ipynb
@@ -30,12 +30,34 @@
     "\n",
     "default_renderer = TextRenderer(background_color=conditional_expression)\n",
     "\n",
+    "dataframe = pd.DataFrame(np.random.randn(100, 100))\n",
+    "\n",
     "streaming_datagrid = StreamingDataGrid(\n",
-    "    pd.DataFrame(np.random.randn(1000, 1000)), \n",
+    "    dataframe, \n",
     "    default_renderer=default_renderer, \n",
     "    debounce_delay=50\n",
     ")\n",
     "streaming_datagrid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b064d19c-24a2-462e-94d9-bfb0241d0d57",
+   "metadata": {},
+   "source": [
+    "The `StreamingDataGrid` class provides a `tick()` method to for notifying that the underlying dataframe has changed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b50d175c-4a38-43e0-b20f-ccb8a86e6add",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_columns = pd.DataFrame(np.random.randn(100, 100))\n",
+    "dataframe.update(new_columns)\n",
+    "streaming_datagrid.tick()"
    ]
   }
  ],

--- a/examples/Streaming.ipynb
+++ b/examples/Streaming.ipynb
@@ -30,17 +30,13 @@
     "\n",
     "default_renderer = TextRenderer(background_color=conditional_expression)\n",
     "\n",
-    "streaming_datagrid = StreamingDataGrid(pd.DataFrame(np.random.randn(1000, 1000)), default_renderer=default_renderer)\n",
+    "streaming_datagrid = StreamingDataGrid(\n",
+    "    pd.DataFrame(np.random.randn(1000, 1000)), \n",
+    "    default_renderer=default_renderer, \n",
+    "    debounce_delay=50\n",
+    ")\n",
     "streaming_datagrid"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "23bccb80-e366-403c-ba32-326c468f40dc",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/Streaming.ipynb
+++ b/examples/Streaming.ipynb
@@ -7,7 +7,9 @@
    "source": [
     "# Streaming datagrid\n",
     "\n",
-    "ipydatagrid provides the ability to lazily request data to the back-end. This requires a live kernel (does not work with a notebook exported to static HTML with nbconvert)."
+    "ipydatagrid provides the ability to lazily request data to the back-end. This requires a live kernel (does not work with a notebook exported to static HTML with nbconvert).\n",
+    "\n",
+    "This feature allows a **smaller memory footprint for the grid**, and **reduced loading time for the initial grid display.**"
    ]
   },
   {
@@ -45,7 +47,7 @@
    "id": "b064d19c-24a2-462e-94d9-bfb0241d0d57",
    "metadata": {},
    "source": [
-    "The `StreamingDataGrid` class provides a `tick()` method to for notifying that the underlying dataframe has changed."
+    "The `StreamingDataGrid` class provides a `tick()` method to for notifying that the underlying dataframe has changed. **This method CANNOT be called in a loop**, due to its implementation. In fact, the front-end cannot request back the viewport for each iteration, because the kernel is already busy executing the loop and cannot respond back until the execution has finished."
    ]
   },
   {

--- a/examples/Streaming.ipynb
+++ b/examples/Streaming.ipynb
@@ -7,6 +7,8 @@
    "source": [
     "# Streaming datagrid\n",
     "\n",
+    "**This is a new feature preview, if you see any issue with this. Please fill out an issue on Github!**\n",
+    "\n",
     "ipydatagrid provides the ability to lazily request data to the back-end. This requires a live kernel (does not work with a notebook exported to static HTML with nbconvert).\n",
     "\n",
     "This feature allows a **smaller memory footprint for the grid**, and **reduced loading time for the initial grid display.**"
@@ -35,8 +37,8 @@
     "dataframe = pd.DataFrame(np.random.randn(100, 100))\n",
     "\n",
     "streaming_datagrid = StreamingDataGrid(\n",
-    "    dataframe, \n",
-    "    default_renderer=default_renderer, \n",
+    "    dataframe,\n",
+    "    default_renderer=default_renderer,\n",
     "    debounce_delay=50\n",
     ")\n",
     "streaming_datagrid"

--- a/examples/Streaming.ipynb
+++ b/examples/Streaming.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f7b949b7-2818-45fa-bb1a-5d1d4e99a403",
+   "metadata": {},
+   "source": [
+    "# Streaming datagrid\n",
+    "\n",
+    "ipydatagrid provides the ability to lazily request data to the back-end. This requires a live kernel (does not work with a notebook exported to static HTML with nbconvert)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6d44983-b311-46d3-8bf4-951dc163574e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipydatagrid import DataGrid, StreamingDataGrid, TextRenderer, BarRenderer, Expr, ImageRenderer\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def renderer_function(cell, default_value):\n",
+    "    return \"#fc8403\" if cell.value < SQRT1_2 else default_value\n",
+    "\n",
+    "\n",
+    "conditional_expression = Expr(renderer_function)\n",
+    "\n",
+    "default_renderer = TextRenderer(background_color=conditional_expression)\n",
+    "\n",
+    "streaming_datagrid = StreamingDataGrid(pd.DataFrame(np.random.randn(1000, 1000)), default_renderer=default_renderer)\n",
+    "streaming_datagrid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23bccb80-e366-403c-ba32-326c468f40dc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/Trees_paris.ipynb
+++ b/examples/Trees_paris.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "from py2vega.functions.color import rgb\n",
     "\n",
-    "from ipydatagrid import DataGrid, TextRenderer, BarRenderer, Expr\n",
+    "from ipydatagrid import StreamingDataGrid, TextRenderer, BarRenderer, Expr\n",
     "\n",
     "with open(\"./trees.json\") as fobj:\n",
     "    data = load(fobj)\n",
@@ -102,10 +102,38 @@
     "    ),\n",
     "}\n",
     "\n",
-    "datagrid = DataGrid(\n",
+    "datagrid = StreamingDataGrid(\n",
     "    df, base_row_size=32, base_column_size=90, renderers=renderers\n",
     ")\n",
     "VBox((highlight_box, datagrid))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.iloc[87642]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datagrid._handle_comm_msg(\n",
+    "    None,\n",
+    "    dict(\n",
+    "        type=\"data-request\",\n",
+    "        r1=87641,\n",
+    "        r2=87643,\n",
+    "        c1=0,\n",
+    "        c2=3,\n",
+    "    ),\n",
+    "    None\n",
+    ")"
    ]
   },
   {

--- a/ipydatagrid/__init__.py
+++ b/ipydatagrid/__init__.py
@@ -12,7 +12,7 @@ from .cellrenderer import (
     TextRenderer,
     VegaExpr,
 )
-from .datagrid import DataGrid, SelectionHelper
+from .datagrid import StreamingDataGrid, DataGrid, SelectionHelper
 
 
 def _jupyter_nbextension_paths():

--- a/ipydatagrid/__init__.py
+++ b/ipydatagrid/__init__.py
@@ -40,6 +40,7 @@ __all__ = [
     "TextRenderer",
     "HtmlRenderer",
     "VegaExpr",
+    "StreamingDataGrid",
     "DataGrid",
     "SelectionHelper",
 ]

--- a/ipydatagrid/__init__.py
+++ b/ipydatagrid/__init__.py
@@ -12,7 +12,7 @@ from .cellrenderer import (
     TextRenderer,
     VegaExpr,
 )
-from .datagrid import StreamingDataGrid, DataGrid, SelectionHelper
+from .datagrid import DataGrid, SelectionHelper, StreamingDataGrid
 
 
 def _jupyter_nbextension_paths():

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -996,9 +996,13 @@ class StreamingDataGrid(DataGrid):
     _view_name = Unicode("StreamingDataGridView").tag(sync=True)
 
     _row_count = Int(0).tag(sync=True)
+    _debounce_delay = Int(160).tag(sync=True)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, debounce_delay=160, **kwargs):
         super(StreamingDataGrid, self).__init__(*args, **kwargs)
+
+        self._debounce_delay = debounce_delay
+
         self.on_msg(self._handle_comm_msg)
 
     def transform(self, transform):

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -1038,6 +1038,10 @@ class StreamingDataGrid(DataGrid):
             "fields": self._data_object["fields"],
         }
 
+    def tick(self):
+        """Notify that the underlying dataframe has changed."""
+        self.send({ "event_type": "tick" })
+
     def _handle_comm_msg(self, _, content, buffers):
         event_type = content.get("type", "")
 

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -1062,12 +1062,9 @@ class StreamingDataGrid(DataGrid):
             # Extract all buffers
             buffers = []
             for column in serialized["data"].keys():
-                if not isinstance(serialized["data"][column], list):
-                    if serialized["data"][column]["type"] == "raw":
-                        serialized["data"][column] = serialized["data"][column]["value"]
-                    else:
-                        buffers.append(serialized["data"][column]["value"])
-                        serialized["data"][column]["value"] = len(buffers) - 1
+                if not isinstance(serialized["data"][column], list) and not serialized["data"][column]["type"] == "raw":
+                    buffers.append(serialized["data"][column]["value"])
+                    serialized["data"][column]["value"] = len(buffers) - 1
 
             answer = {
                 "event_type": "data-reply",

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -1063,8 +1063,11 @@ class StreamingDataGrid(DataGrid):
             buffers = []
             for column in serialized["data"].keys():
                 if not isinstance(serialized["data"][column], list):
-                    buffers.append(serialized["data"][column]["value"])
-                    serialized["data"][column]["value"] = len(buffers) - 1
+                    if serialized["data"][column]["type"] == "raw":
+                        serialized["data"][column] = serialized["data"][column]["value"]
+                    else:
+                        buffers.append(serialized["data"][column]["value"])
+                        serialized["data"][column]["value"] = len(buffers) - 1
 
             answer = {
                 "event_type": "data-reply",

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -1041,7 +1041,7 @@ class StreamingDataGrid(DataGrid):
         """Notify that the underlying dataframe has changed."""
         self.send({"event_type": "tick"})
 
-    def _handle_comm_msg(self, _, content, buffers):
+    def _handle_comm_msg(self, _, content, buffs):
         event_type = content.get("type", "")
 
         if event_type == "data-request":
@@ -1062,8 +1062,9 @@ class StreamingDataGrid(DataGrid):
             # Extract all buffers
             buffers = []
             for column in serialized["data"].keys():
-                buffers.append(serialized["data"][column]["value"])
-                serialized["data"][column]["value"] = len(buffers) - 1
+                if not isinstance(serialized["data"][column], list):
+                    buffers.append(serialized["data"][column]["value"])
+                    serialized["data"][column]["value"] = len(buffers) - 1
 
             answer = {
                 "event_type": "data-reply",

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -1017,6 +1017,9 @@ class StreamingDataGrid(DataGrid):
         # Not making a copy in the streaming grid
         self.__dataframe_reference = dataframe
 
+        # TODO support column indices being integers
+        dataframe.columns = dataframe.columns.map(str)
+
         # Primary key used
         index_key = self.get_dataframe_index(dataframe)
 

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -1037,10 +1037,6 @@ class StreamingDataGrid(DataGrid):
             fields=self._data_object["fields"],
         )
 
-        from ipywidgets import Output
-
-        self._out = Output()
-
     def _handle_comm_msg(self, _, content, buffers):
         event_type = content.get("type", "")
 
@@ -1073,7 +1069,5 @@ class StreamingDataGrid(DataGrid):
                 c1=c1,
                 c2=c2,
             )
-            with self._out:
-                self.send(answer, buffers)
 
-            return
+            self.send(answer, buffers)

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -1,7 +1,6 @@
 # Copyright (c) NumFOCUS.
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
 import datetime
 import decimal
 import warnings
@@ -989,7 +988,8 @@ class DataGrid(DOMWidget):
 
 class StreamingDataGrid(DataGrid):
     """A blazingly fast Grid Widget.
-    This widget needs a live kernel for working (does not work when embedded in static HTML)
+    This widget needs a live kernel for working
+    (does not work when embedded in static HTML)
     """
 
     _model_name = Unicode("StreamingDataGridModel").tag(sync=True)
@@ -1005,10 +1005,11 @@ class StreamingDataGrid(DataGrid):
 
         self.on_msg(self._handle_comm_msg)
 
-    def transform(self, transform):
+    def transform(self, _):
         # TODO Implement sorting and filtering backend-side?
         raise RuntimeError(
-            "Setting filters and sorting rules to a StreamingDataGrid is not supported."
+            "Setting filters and sorting rules to a "
+            "StreamingDataGrid is not supported."
         )
 
     @property
@@ -1031,11 +1032,11 @@ class StreamingDataGrid(DataGrid):
 
         self._row_count = len(self._data_object["data"])
 
-        self._data = dict(
-            data={},
-            schema=self._data_object["schema"],
-            fields=self._data_object["fields"],
-        )
+        self._data = {
+            "data": {},
+            "schema": self._data_object["schema"],
+            "fields": self._data_object["fields"],
+        }
 
     def _handle_comm_msg(self, _, content, buffers):
         event_type = content.get("type", "")
@@ -1061,13 +1062,13 @@ class StreamingDataGrid(DataGrid):
                 buffers.append(serialized["data"][column]["value"])
                 serialized["data"][column]["value"] = len(buffers) - 1
 
-            answer = dict(
-                event_type="data-reply",
-                value=serialized,
-                r1=r1,
-                r2=r2,
-                c1=c1,
-                c2=c2,
-            )
+            answer = {
+                "event_type": "data-reply",
+                "value": serialized,
+                "r1": r1,
+                "r2": r2,
+                "c1": c1,
+                "c2": c2,
+            }
 
             self.send(answer, buffers)

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -23,7 +23,6 @@ from traitlets import (
     default,
     validate,
 )
-from bqplot.traits import array_to_json
 
 from ._frontend import module_name, module_version
 from .cellrenderer import BarRenderer, CellRenderer, TextRenderer
@@ -999,7 +998,7 @@ class StreamingDataGrid(DataGrid):
     _debounce_delay = Int(160).tag(sync=True)
 
     def __init__(self, *args, debounce_delay=160, **kwargs):
-        super(StreamingDataGrid, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self._debounce_delay = debounce_delay
 
@@ -1014,7 +1013,7 @@ class StreamingDataGrid(DataGrid):
 
     @property
     def data(self):
-        return super(StreamingDataGrid, self).data
+        return super().data
 
     @data.setter
     def data(self, dataframe):
@@ -1040,7 +1039,7 @@ class StreamingDataGrid(DataGrid):
 
     def tick(self):
         """Notify that the underlying dataframe has changed."""
-        self.send({ "event_type": "tick" })
+        self.send({"event_type": "tick"})
 
     def _handle_comm_msg(self, _, content, buffers):
         event_type = content.get("type", "")

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -1006,13 +1006,6 @@ class StreamingDataGrid(DataGrid):
 
         self.on_msg(self._handle_comm_msg)
 
-    def transform(self, _):
-        # TODO Implement sorting and filtering backend-side?
-        raise RuntimeError(
-            "Setting filters and sorting rules to a "
-            "StreamingDataGrid is not supported."
-        )
-
     @property
     def data(self):
         return super().data

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -1041,7 +1041,7 @@ class StreamingDataGrid(DataGrid):
         """Notify that the underlying dataframe has changed."""
         self.send({"event_type": "tick"})
 
-    def _handle_comm_msg(self, _, content, buffs):
+    def _handle_comm_msg(self, _, content, _buffs):
         event_type = content.get("type", "")
 
         if event_type == "data-request":
@@ -1062,7 +1062,10 @@ class StreamingDataGrid(DataGrid):
             # Extract all buffers
             buffers = []
             for column in serialized["data"].keys():
-                if not isinstance(serialized["data"][column], list) and not serialized["data"][column]["type"] == "raw":
+                if (
+                    not isinstance(serialized["data"][column], list)
+                    and not serialized["data"][column]["type"] == "raw"
+                ):
                     buffers.append(serialized["data"][column]["value"])
                     serialized["data"][column]["value"] = len(buffers) - 1
 

--- a/js/core/deserialize.ts
+++ b/js/core/deserialize.ts
@@ -1,0 +1,96 @@
+import { Dict } from '@jupyter-widgets/base';
+import { array_or_json_serializer } from 'bqplot';
+import { DataSource } from '../datasource';
+
+export function unpack_raw_data(
+  value: any | Dict<unknown> | string | (Dict<unknown> | string)[],
+): any {
+  if (Array.isArray(value)) {
+    const unpacked: any[] = [];
+    value.forEach((sub_value, key) => {
+      unpacked.push(unpack_raw_data(sub_value));
+    });
+    return unpacked;
+  } else if (value instanceof Object && typeof value !== 'string') {
+    const unpacked: { [key: string]: any } = {};
+    Object.keys(value).forEach((key) => {
+      unpacked[key] = unpack_raw_data(value[key]);
+    });
+    return unpacked;
+  } else if (value === '$NaN$') {
+    return Number.NaN;
+  } else if (value === '$Infinity$') {
+    return Number.POSITIVE_INFINITY;
+  } else if (value === '$NegInfinity$') {
+    return Number.NEGATIVE_INFINITY;
+  } else if (value === '$NaT$') {
+    return new Date('INVALID');
+  } else {
+    return value;
+  }
+}
+
+export function deserialize_data_simple(data: any, manager: any): any {
+  const deserialized_data: any = {};
+
+  // Backward compatibility for when data.data was an array of rows
+  // (should be removed in ipydatagrid 2.x?)
+  if (Array.isArray(data.data)) {
+    if (data.data.length === 0) {
+      return deserialized_data;
+    }
+
+    const unpacked = unpack_raw_data(data.data);
+    // Turn array of rows (old approach) into a dictionary of columns as arrays (new approach)
+    for (const column of Object.keys(unpacked[0])) {
+      const columnData = new Array(unpacked.length);
+      let rowIdx = 0;
+
+      for (const row of unpacked) {
+        columnData[rowIdx++] = row[column];
+      }
+
+      deserialized_data[column] = columnData;
+    }
+
+    return deserialized_data;
+  }
+
+  for (const column of Object.keys(data.data)) {
+    deserialized_data[column] = [];
+
+    if (Array.isArray(data.data[column])) {
+      deserialized_data[column] = data.data[column];
+      continue;
+    }
+
+    if (data.data[column].type == 'raw') {
+      deserialized_data[column] = unpack_raw_data(data.data[column].value);
+    } else {
+      if (data.data[column].value.length !== 0) {
+        let deserialized_array = array_or_json_serializer.deserialize(
+          data.data[column],
+          manager,
+        );
+
+        // Turning back float32 dates into isoformat
+        if (deserialized_array.type === 'date') {
+          const float32Array = deserialized_array;
+          deserialized_array = [];
+
+          for (let i = 0; i < float32Array.length; i++) {
+            deserialized_array[i] = new Date(float32Array[i]).toISOString();
+          }
+        }
+
+        deserialized_data[column] = deserialized_array;
+      }
+    }
+  }
+  return deserialized_data
+}
+
+export function deserialize_data(data: any, manager: any): DataSource {
+  const deserialized = deserialize_data_simple(data, manager);
+  return new DataSource(deserialized, data.fields, data.schema, true);
+}

--- a/js/core/filterMenu.ts
+++ b/js/core/filterMenu.ts
@@ -264,7 +264,9 @@ export class InteractiveFilterDialog extends BoxPanel {
         primaryKeyUuid: 'index',
       },
     );
-    this._uniqueValueGrid.dataModel = new ViewBasedJSONModel(data);
+    this._uniqueValueGrid.dataModel = new ViewBasedJSONModel({
+      datasource: data,
+    });
     const sortTransform: Transform.Sort = {
       type: 'sort',
       column: 'uniqueVals',

--- a/js/core/streamingview.ts
+++ b/js/core/streamingview.ts
@@ -1,0 +1,140 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+import { DataModel } from '@lumino/datagrid';
+import { View } from './view';
+import { DataSource } from '../datasource';
+
+/**
+ * A View implementation for immutable in-memory JSON data.
+ *
+ * Note: Most of this is just repurposed from JSONModel, and can likely be
+ * streamlined quite a bit.
+ */
+export class StreamingView extends View {
+  /**
+   * Create a view with streaming data.
+   *
+   * @param options - The datasource for initializing the view.
+   */
+  constructor(options: StreamingView.IOptions) {
+    super(options.datasource);
+
+    this._rowCount = options.rowCount;
+    this._streamed_data = [];
+  }
+
+  /**
+   * Get the row count for a region in the view.
+   *
+   * @param region - The row region of interest.
+   *
+   * @returns - The row count for the region.
+   */
+  rowCount(region: DataModel.RowRegion): number {
+    if (region === 'body') {
+      return this._rowCount;
+    } else {
+      return this._bodyFields[0].rows.length;
+    }
+  }
+
+  /**
+   * Get the data value for a cell in the view.
+   *
+   * @param region - The cell region of interest.
+   *
+   * @param row - The row index of the cell of interest.
+   *
+   * @param column - The column index of the cell of interest.
+   *
+   * @param returns - The data value for the specified cell.
+   *
+   * #### Notes
+   * A `missingValue` as defined by the schema is converted to `null`.
+   */
+  data(region: DataModel.CellRegion, row: number, column: number): any {
+    if (region == 'body') {
+      if (this._streamed_data[row] === undefined) {
+        this._streamed_data[row] = [];
+      }
+      const value = this._streamed_data[row][column];
+      return value !== undefined ? value : '';
+    }
+
+    if (region == 'row-header') {
+      return 'TODO';
+    }
+
+    return super.data(region, row, column);
+  }
+
+  setDataRange(
+    r1: number,
+    r2: number,
+    c1: number,
+    c2: number,
+    value: DataSource,
+  ) {
+    let field: DataSource.IField;
+    let r = 0;
+
+    for (let row = r1; row <= r2; row++) {
+      if (this._streamed_data[row] === undefined) {
+        this._streamed_data[row] = [];
+      }
+      for (let column = c1; column <= c2; column++) {
+        field = this._bodyFields[column];
+
+        this._streamed_data[row][column] = value.data[field.name][r];
+      }
+      r++;
+    }
+  }
+
+  setData(value: any, row: number, column: number) {
+    if (this._streamed_data[row] === undefined) {
+      this._streamed_data[row] = [];
+    }
+
+    if (this._streamed_data[row][column] === undefined) {
+      this._streamed_data[row][column] = [];
+    }
+
+    this._streamed_data[row][column] = value;
+  }
+
+  hasData(row: number, column: number): boolean {
+    if (this._streamed_data[row] === undefined) {
+      return false;
+    }
+
+    if (this._streamed_data[row][column] === undefined) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private _streamed_data: any[][];
+  private readonly _rowCount: number;
+}
+
+export namespace StreamingView {
+  export interface IOptions {
+    /**
+     * The datasource.
+     */
+    datasource: DataSource;
+
+    /**
+     * The row number of the grid.
+     */
+    rowCount: number;
+  }
+}

--- a/js/core/streamingview.ts
+++ b/js/core/streamingview.ts
@@ -135,20 +135,6 @@ export class StreamingView extends View {
     this._streamed_data[field.name][row] = value;
   }
 
-  hasData(row: number, column: number): boolean {
-    const field = this._bodyFields[column];
-
-    if (this._streamed_data[field.name] === undefined) {
-      return false;
-    }
-
-    if (this._streamed_data[field.name][row] === undefined) {
-      return false;
-    }
-
-    return true;
-  }
-
   private _streamed_data: Dict<any[]> = {};
   private readonly _rowCount: number;
 }

--- a/js/core/streamingview.ts
+++ b/js/core/streamingview.ts
@@ -91,6 +91,9 @@ export class StreamingView extends View {
     c2: number,
     value: DataSource,
   ) {
+    // Columns need to be set some time, not sure if this is the best place.
+    this._data.setColumns(value.columns);
+
     let field: DataSource.IField;
 
     // Update body
@@ -135,8 +138,12 @@ export class StreamingView extends View {
     this._streamed_data[field.name][row] = value;
   }
 
+  setRowCount(rowCount: number) {
+    this._rowCount = rowCount;
+  }
+
   private _streamed_data: Dict<any[]> = {};
-  private readonly _rowCount: number;
+  private _rowCount: number;
 }
 
 export namespace StreamingView {

--- a/js/core/streamingviewbasedjsonmodel.ts
+++ b/js/core/streamingviewbasedjsonmodel.ts
@@ -55,11 +55,11 @@ export class StreamingViewBasedJSONModel extends ViewBasedJSONModel {
     this._currentView.setData(options.value, options.row, options.column);
   }
 
-  protected get currentView(): StreamingView {
+  get currentView(): StreamingView {
     return this._currentView;
   }
 
-  protected set currentView(view: StreamingView) {
+  set currentView(view: StreamingView) {
     super.currentView = view;
   }
 

--- a/js/core/streamingviewbasedjsonmodel.ts
+++ b/js/core/streamingviewbasedjsonmodel.ts
@@ -28,6 +28,15 @@ export class StreamingViewBasedJSONModel extends ViewBasedJSONModel {
       rowSpan: r2 - r1 + 1,
       columnSpan: c2 - c1 + 1,
     });
+
+    this.emitChanged({
+      type: 'cells-changed',
+      region: 'row-header',
+      row: r1,
+      column: 0,
+      rowSpan: r2 - r1 + 1,
+      columnSpan: this._currentView.columnCount('row-header'),
+    });
   }
 
   updateDataset(options: StreamingViewBasedJSONModel.IOptions): void {

--- a/js/core/streamingviewbasedjsonmodel.ts
+++ b/js/core/streamingviewbasedjsonmodel.ts
@@ -1,4 +1,3 @@
-import { DataModel } from '@lumino/datagrid';
 import { StreamingView } from './streamingview';
 import { ViewBasedJSONModel } from './viewbasedjsonmodel';
 import { DataSource } from '../datasource';
@@ -47,13 +46,6 @@ export class StreamingViewBasedJSONModel extends ViewBasedJSONModel {
       rowCount: options.rowCount,
     });
     this.currentView = view;
-  }
-
-  data(region: DataModel.CellRegion, row: number, column: number): any {
-    if (region === 'body' && !this.currentView.hasData(row, column)) {
-      return '...';
-    }
-    return this.currentView.data(region, row, column);
   }
 
   updateCellValue(options: ViewBasedJSONModel.IUpdateCellValuesOptions): void {

--- a/js/core/streamingviewbasedjsonmodel.ts
+++ b/js/core/streamingviewbasedjsonmodel.ts
@@ -1,0 +1,78 @@
+import { DataModel } from '@lumino/datagrid';
+import { StreamingView } from './streamingview';
+import { ViewBasedJSONModel } from './viewbasedjsonmodel';
+import { DataSource } from '../datasource';
+
+/**
+ * A view based data model implementation for in-memory JSON data.
+ */
+export class StreamingViewBasedJSONModel extends ViewBasedJSONModel {
+  constructor(options: StreamingViewBasedJSONModel.IOptions) {
+    super(options);
+  }
+
+  setModelRangeData(
+    r1: number,
+    r2: number,
+    c1: number,
+    c2: number,
+    value: DataSource,
+  ) {
+    this._currentView.setDataRange(r1, r2, c1, c2, value);
+
+    this.emitChanged({
+      type: 'cells-changed',
+      region: 'body',
+      row: r1,
+      column: c1,
+      rowSpan: r2 - r1 + 1,
+      columnSpan: c2 - c1 + 1,
+    });
+  }
+
+  updateDataset(options: StreamingViewBasedJSONModel.IOptions): void {
+    this._dataset = options.datasource;
+    this._updatePrimaryKeyMap();
+    const view = new StreamingView({
+      datasource: this._dataset,
+      rowCount: options.rowCount,
+    });
+    this.currentView = view;
+  }
+
+  data(region: DataModel.CellRegion, row: number, column: number): any {
+    if (region === 'body' && !this.currentView.hasData(row, column)) {
+      return '...';
+    }
+    return this.currentView.data(region, row, column);
+  }
+
+  updateCellValue(options: ViewBasedJSONModel.IUpdateCellValuesOptions): void {
+    if (options.region != 'body') {
+      return;
+    }
+    this._currentView.setData(options.value, options.row, options.column);
+  }
+
+  protected get currentView(): StreamingView {
+    return this._currentView;
+  }
+
+  protected set currentView(view: StreamingView) {
+    super.currentView = view;
+  }
+
+  protected _currentView: StreamingView;
+}
+
+export namespace StreamingViewBasedJSONModel {
+  /**
+   * An options object for initializing the data model.
+   */
+  export interface IOptions extends ViewBasedJSONModel.IOptions {
+    /**
+     * The row number of the grid.
+     */
+    rowCount: number;
+  }
+}

--- a/js/core/view.ts
+++ b/js/core/view.ts
@@ -164,10 +164,10 @@ export class View {
     return Array.from(new Set(this.dataset.data[column]));
   }
 
-  private readonly _data: DataSource | Readonly<DataSource>;
-  private readonly _bodyFields: DataSource.IField[];
-  private readonly _headerFields: DataSource.IField[];
-  private readonly _missingValues: Private.MissingValuesMap | null;
+  protected readonly _data: DataSource | Readonly<DataSource>;
+  protected readonly _bodyFields: DataSource.IField[];
+  protected readonly _headerFields: DataSource.IField[];
+  protected readonly _missingValues: Private.MissingValuesMap | null;
 }
 
 /**

--- a/js/core/viewbasedjsonmodel.ts
+++ b/js/core/viewbasedjsonmodel.ts
@@ -20,11 +20,11 @@ export class ViewBasedJSONModel extends MutableDataModel {
   /**
    * Create a data model with static JSON data.
    *
-   * @param data - The dataset for initializing the data model.
+   * @param options - The options for creating the data model.
    */
-  constructor(data: DataSource) {
+  constructor(options: ViewBasedJSONModel.IOptions) {
     super();
-    this.updateDataset(data);
+    this.updateDataset(options);
 
     this._transformState = new TransformStateManager();
     // Repaint grid on transform state update
@@ -72,10 +72,10 @@ export class ViewBasedJSONModel extends MutableDataModel {
   /**
    * Sets the dataset for this model.
    *
-   * @param data - The data to be set on this data model
+   * @param options - The options for creating the model
    */
-  updateDataset(data: DataSource): void {
-    this._dataset = data;
+  updateDataset(options: ViewBasedJSONModel.IOptions): void {
+    this._dataset = options.datasource;
     this._updatePrimaryKeyMap();
     const view = new View(this._dataset);
     this.currentView = view;
@@ -85,7 +85,7 @@ export class ViewBasedJSONModel extends MutableDataModel {
    * Updates the primary key map, which provides a mapping from primary key
    * value to row in the full dataset.
    */
-  private _updatePrimaryKeyMap(): void {
+  protected _updatePrimaryKeyMap(): void {
     this._primaryKeyMap.clear();
 
     const primaryKey = this._dataset.schema.primaryKey as string[];
@@ -594,7 +594,7 @@ export class ViewBasedJSONModel extends MutableDataModel {
     return this.currentView.getSchemaIndex(region, index);
   }
 
-  private _currentView: View;
+  protected _currentView: View;
   private _transformSignal = new Signal<this, TransformStateManager.IEvent>(
     this,
   );
@@ -615,6 +615,13 @@ export class ViewBasedJSONModel extends MutableDataModel {
  * The namespace for the `ViewBasedJSONModel` class statics.
  */
 export namespace ViewBasedJSONModel {
+  export interface IOptions {
+    /**
+     * The `DataSource` for the model.
+     */
+    datasource: DataSource;
+  }
+
   export interface IUpdateCellValuesOptions {
     /**
      * The `CellRegion` of the cell to be updated.

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -26,6 +26,7 @@ import {
   resolvePromisesDict,
   unpack_models,
   WidgetModel,
+  WidgetView,
 } from '@jupyter-widgets/base';
 
 import { array_or_json_serializer } from 'bqplot';
@@ -954,6 +955,18 @@ export class StreamingDataGridModel extends DataGridModel {
 }
 
 export class StreamingDataGridView extends DataGridView {
+  initialize(parameters: WidgetView.IInitializeParameters<WidgetModel>): void {
+    super.initialize(parameters);
+
+    this.model.on('msg:custom', (content, _) => {
+      if (content.event_type === 'tick') {
+        this.grid.tick();
+
+        return;
+      }
+    });
+  }
+
   protected _createGrid(): StreamingFeatherGrid {
     return new StreamingFeatherGrid({
       defaultSizes: {
@@ -974,4 +987,5 @@ export class StreamingDataGridView extends DataGridView {
   }
 
   model: StreamingDataGridModel;
+  grid: StreamingFeatherGrid;
 }

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -260,15 +260,12 @@ export class DataGridModel extends DOMWidgetModel {
 
   updateTransforms() {
     const transforms = this.get('_transforms');
-    if (this.get('_transform_on_backend')) {
-      const msg = { type: 'frontend-transforms', transforms: transforms };
-      this.send(msg);
-    } else {
+    if (!this.get('_transform_on_backend')) {
       if (this.selectionModel) {
         this.selectionModel.clear();
       }
-      this.data_model.replaceTransforms(transforms);
     }
+    this.data_model.replaceTransforms(transforms);
   }
 
   updateSelectionModel() {

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -31,6 +31,7 @@ import {
 
 import { array_or_json_serializer } from 'bqplot';
 
+import { deserialize_data } from './core/deserialize';
 import { ViewBasedJSONModel } from './core/viewbasedjsonmodel';
 import { StreamingViewBasedJSONModel } from './core/streamingviewbasedjsonmodel';
 
@@ -45,34 +46,6 @@ import { DataSource } from './datasource';
 // Import CSS
 import '../style/jupyter-widget.css';
 
-function unpack_raw_data(
-  value: any | Dict<unknown> | string | (Dict<unknown> | string)[],
-): any {
-  if (Array.isArray(value)) {
-    const unpacked: any[] = [];
-    value.forEach((sub_value, key) => {
-      unpacked.push(unpack_raw_data(sub_value));
-    });
-    return unpacked;
-  } else if (value instanceof Object && typeof value !== 'string') {
-    const unpacked: { [key: string]: any } = {};
-    Object.keys(value).forEach((key) => {
-      unpacked[key] = unpack_raw_data(value[key]);
-    });
-    return unpacked;
-  } else if (value === '$NaN$') {
-    return Number.NaN;
-  } else if (value === '$Infinity$') {
-    return Number.POSITIVE_INFINITY;
-  } else if (value === '$NegInfinity$') {
-    return Number.NEGATIVE_INFINITY;
-  } else if (value === '$NaT$') {
-    return new Date('INVALID');
-  } else {
-    return value;
-  }
-}
-
 function serialize_data(data: DataSource, manager: any): any {
   const serialized_data: any = {};
   for (const column of Object.keys(data.data)) {
@@ -82,66 +55,6 @@ function serialize_data(data: DataSource, manager: any): any {
     );
   }
   return { data: serialized_data, fields: data.fields, schema: data.schema };
-}
-
-function deserialize_data(data: any, manager: any): DataSource {
-  const deserialized_data: any = {};
-
-  // Backward compatibility for when data.data was an array of rows
-  // (should be removed in ipydatagrid 2.x?)
-  if (Array.isArray(data.data)) {
-    if (data.data.length === 0) {
-      return new DataSource(deserialized_data, data.fields, data.schema, true);
-    }
-
-    const unpacked = unpack_raw_data(data.data);
-    // Turn array of rows (old approach) into a dictionary of columns as arrays (new approach)
-    for (const column of Object.keys(unpacked[0])) {
-      const columnData = new Array(unpacked.length);
-      let rowIdx = 0;
-
-      for (const row of unpacked) {
-        columnData[rowIdx++] = row[column];
-      }
-
-      deserialized_data[column] = columnData;
-    }
-
-    return new DataSource(deserialized_data, data.fields, data.schema, true);
-  }
-
-  for (const column of Object.keys(data.data)) {
-    deserialized_data[column] = [];
-
-    if (Array.isArray(data.data[column])) {
-      deserialized_data[column] = data.data[column];
-      continue;
-    }
-
-    if (data.data[column].type == 'raw') {
-      deserialized_data[column] = unpack_raw_data(data.data[column].value);
-    } else {
-      if (data.data[column].value.length !== 0) {
-        let deserialized_array = array_or_json_serializer.deserialize(
-          data.data[column],
-          manager,
-        );
-
-        // Turning back float32 dates into isoformat
-        if (deserialized_array.type === 'date') {
-          const float32Array = deserialized_array;
-          deserialized_array = [];
-
-          for (let i = 0; i < float32Array.length; i++) {
-            deserialized_array[i] = new Date(float32Array[i]).toISOString();
-          }
-        }
-
-        deserialized_data[column] = deserialized_array;
-      }
-    }
-  }
-  return new DataSource(deserialized_data, data.fields, data.schema, true);
 }
 
 export class DataGridModel extends DOMWidgetModel {

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -903,10 +903,13 @@ export class StreamingDataGridModel extends DataGridModel {
       if (content.event_type === 'data-reply') {
         // Bring back buffers at their original position in the data structure
         for (const column of Object.keys(content.value.data)) {
-          content.value.data[column].value =
-            buffers[content.value.data[column].value];
+          if (content.value.data[column].type !== 'raw') {
+            content.value.data[column].value =
+              buffers[content.value.data[column].value];
+          }
         }
 
+        console.log('set data')
         const deserialized = deserialize_data(content.value, null);
         this.data_model.setModelRangeData(
           content.r1,

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -891,6 +891,7 @@ export class StreamingDataGridModel extends DataGridModel {
       _view_name: StreamingDataGridModel.view_name,
       _row_count: 0,
       _data: {},
+      _debounce_delay: 160,
     };
   }
 
@@ -963,6 +964,7 @@ export class StreamingDataGridView extends DataGridView {
       },
       headerVisibility: this.model.get('header_visibility'),
       style: this.model.get('grid_style'),
+      debounceDelay: this.model.get('_debounce_delay'),
       requestData: this.requestData.bind(this),
     });
   }

--- a/js/datasource.ts
+++ b/js/datasource.ts
@@ -41,7 +41,7 @@ export class DataSource {
       return 0;
     }
 
-    return this._data[this._columns[0]].length;
+    return this.data[this._columns[0]].length;
   }
 
   private _createSchema(

--- a/js/datasource.ts
+++ b/js/datasource.ts
@@ -44,6 +44,10 @@ export class DataSource {
     return this.data[this._columns[0]].length;
   }
 
+  setColumns(columnNames: string[]) {
+    this._columns = columnNames;
+  }
+
   private _createSchema(
     origFields: Dict<any>,
     origSchema: any,

--- a/js/feathergrid.ts
+++ b/js/feathergrid.ts
@@ -124,6 +124,10 @@ export class FeatherGrid extends Widget {
 
     this._createGrid(options);
 
+    if (this.backboneModel) {
+      this.grid.copyConfig = this.backboneModel.get('copy_config');
+    }
+
     this._defaultRenderer = new TextRenderer({
       font: '12px sans-serif',
       textColor: Theme.getFontColor(),

--- a/js/streamingfeathergrid.ts
+++ b/js/streamingfeathergrid.ts
@@ -1,0 +1,82 @@
+import { DataGrid } from '@lumino/datagrid';
+import { Debouncer } from '@lumino/polling';
+import { IMessageHandler, Message } from '@lumino/messaging';
+import { FeatherGrid } from './feathergrid';
+
+export class StreamingFeatherGrid extends FeatherGrid {
+  constructor(options: StreamingFeatherGrid.IOptions) {
+    super(options);
+
+    this._requestData = options.requestData;
+
+    this._pullData = new Debouncer(this.pullDataImpl.bind(this), 160);
+  }
+
+  messageHook(handler: IMessageHandler, msg: Message): boolean {
+    if (handler === this.grid.viewport) {
+      if (
+        msg.type === 'scroll-request' ||
+        msg.type === 'resize' ||
+        msg.type === 'row-resize-request' ||
+        msg.type === 'column-resize-request'
+      ) {
+        this._pullData.invoke();
+      }
+    }
+
+    return true;
+  }
+
+  private pullDataImpl() {
+    let width = this.grid.viewport.node.offsetWidth;
+    let height = this.grid.viewport.node.offsetHeight;
+
+    width = Math.round(width);
+    height = Math.round(height);
+
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+
+    // @ts-ignore
+    const contentW = this.grid._columnSections.length - this.grid.scrollX;
+    // @ts-ignore
+    const contentH = this.grid._rowSections.length - this.grid.scrollY;
+
+    const contentX = this.grid.headerWidth;
+    const contentY = this.grid.headerHeight;
+
+    const x1 = contentX;
+    const y1 = contentY;
+    const x2 = Math.min(width - 1, contentX + contentW - 1);
+    const y2 = Math.min(height - 1, contentY + contentH - 1);
+
+    // @ts-ignore
+    const r1 = this.grid._rowSections.indexOf(
+      y1 - contentY + this.grid.scrollY,
+    );
+    // @ts-ignore
+    const c1 = this.grid._columnSections.indexOf(
+      x1 - contentX + this.grid.scrollX,
+    );
+    // @ts-ignore
+    const r2 = this.grid._rowSections.indexOf(
+      y2 - contentY + this.grid.scrollY,
+    );
+    // @ts-ignore
+    const c2 = this.grid._columnSections.indexOf(
+      x2 - contentX + this.grid.scrollX,
+    );
+
+    this._requestData(r1, r2, c1, c2);
+  }
+
+  private _requestData: any;
+  private _pullData: Debouncer;
+}
+
+export namespace StreamingFeatherGrid {
+  export interface IOptions extends DataGrid.IOptions {
+    requestData: any;
+  }
+}

--- a/js/streamingfeathergrid.ts
+++ b/js/streamingfeathergrid.ts
@@ -45,8 +45,9 @@ export class StreamingFeatherGrid extends FeatherGrid {
       return;
     }
 
-    // TODO Contribute upstream to provide public APIs to get the current viewport
-    // This will help us remove those ts-ignores and get rid of low-level code
+    // TODO Remove all this low-level code once https://github.com/jupyterlab/lumino/pull/695 is merged and available
+    // CAUTION WHEN REMOVING, we need an escape path for older Lumino as we don't control its version. Full removal
+    // can only happen when a backward incompatible release is made.
     // @ts-ignore
     const contentW = this.grid._columnSections.length - this.grid.scrollX;
     // @ts-ignore

--- a/js/streamingfeathergrid.ts
+++ b/js/streamingfeathergrid.ts
@@ -9,7 +9,10 @@ export class StreamingFeatherGrid extends FeatherGrid {
 
     this._requestData = options.requestData;
 
-    this._pullData = new Debouncer(this.pullDataImpl.bind(this), 160);
+    this._pullData = new Debouncer(
+      this.pullDataImpl.bind(this),
+      options.debounceDelay,
+    );
   }
 
   messageHook(handler: IMessageHandler, msg: Message): boolean {
@@ -38,6 +41,8 @@ export class StreamingFeatherGrid extends FeatherGrid {
       return;
     }
 
+    // TODO Contribute upstream to provide public APIs to get the current viewport
+    // This will help us remove those ts-ignores and get rid of low-level code
     // @ts-ignore
     const contentW = this.grid._columnSections.length - this.grid.scrollX;
     // @ts-ignore
@@ -71,12 +76,25 @@ export class StreamingFeatherGrid extends FeatherGrid {
     this._requestData(r1, r2, c1, c2);
   }
 
-  private _requestData: any;
+  private _requestData: (
+    r1: number,
+    r2: number,
+    c1: number,
+    c2: number,
+  ) => void;
   private _pullData: Debouncer;
 }
 
 export namespace StreamingFeatherGrid {
   export interface IOptions extends DataGrid.IOptions {
-    requestData: any;
+    /**
+     * The function for requesting data to the back-end.
+     */
+    requestData: (r1: number, r2: number, c1: number, c2: number) => void;
+
+    /**
+     * Delay for debouncing data requests.
+     */
+    debounceDelay: number;
   }
 }

--- a/js/streamingfeathergrid.ts
+++ b/js/streamingfeathergrid.ts
@@ -23,11 +23,15 @@ export class StreamingFeatherGrid extends FeatherGrid {
         msg.type === 'row-resize-request' ||
         msg.type === 'column-resize-request'
       ) {
-        this._pullData.invoke();
+        this.tick();
       }
     }
 
     return true;
+  }
+
+  tick() {
+    this._pullData.invoke();
   }
 
   private pullDataImpl() {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@lumino/default-theme": "^1 || ^2",
     "@lumino/domutils": "^1 || ^2",
     "@lumino/messaging": "^1 || ^2",
+    "@lumino/polling": "^1 || ^2",
     "@lumino/signaling": "^1 || ^2",
     "@lumino/virtualdom": "^1 || ^2",
     "@lumino/widgets": "^1 || ^2",
@@ -141,6 +142,10 @@
         "singleton": true
       },
       "@lumino/coreutils": {
+        "bundled": false,
+        "singleton": true
+      },
+      "@lumino/polling": {
         "bundled": false,
         "singleton": true
       },

--- a/tests/js/arrayUtils.test.ts
+++ b/tests/js/arrayUtils.test.ts
@@ -51,7 +51,7 @@ describe('Test multi index array utilities', () => {
   );
 
   // Creating a model
-  const testModel = new ViewBasedJSONModel(testData.data);
+  const testModel = new ViewBasedJSONModel({ datasource: testData.data });
   // Generating an array with location of nested level headers
   const mutltiIndexArrayLocations =
     ArrayUtils.generateMultiIndexArrayLocations(testModel);

--- a/tests/js/filterMenu.test.ts
+++ b/tests/js/filterMenu.test.ts
@@ -181,7 +181,7 @@ namespace Private {
   export function createSimpleModel(
     data: DataGenerator.ISingleColOptions,
   ): ViewBasedJSONModel {
-    const model = new ViewBasedJSONModel(DataGenerator.singleCol(data).data);
+    const model = new ViewBasedJSONModel({ datasource: DataGenerator.singleCol(data).data });
     return model;
   }
 

--- a/tests/js/viewbasedjsonmodel.test.ts
+++ b/tests/js/viewbasedjsonmodel.test.ts
@@ -133,9 +133,9 @@ describe('Test .uniqueValues()', () => {
       { name: 'col3', type: 'number', data: [100, 200, 100, 300, 200] },
     ],
   });
-  const testModel = new ViewBasedJSONModel(testData.data);
-  test('cellregion-column-header-0', () => {
-    expect(testModel.uniqueValues('column-header', 'col1')).toEqual([
+  const testModel = new ViewBasedJSONModel({ datasource: testData.data });
+  test('cellregion-column-header-0', async () => {
+    expect(await testModel.uniqueValues('column-header', 'col1')).toEqual([
       10,
       20,
       30,
@@ -143,21 +143,21 @@ describe('Test .uniqueValues()', () => {
       50,
     ]);
   });
-  test('cellregion-column-header-1', () => {
-    expect(testModel.uniqueValues('column-header', 'col2')).toEqual([
+  test('cellregion-column-header-1', async () => {
+    expect(await testModel.uniqueValues('column-header', 'col2')).toEqual([
       true,
       false,
     ]);
   });
-  test('cellregion-column-header-2', () => {
-    expect(testModel.uniqueValues('column-header', 'col3')).toEqual([
+  test('cellregion-column-header-2', async () => {
+    expect(await testModel.uniqueValues('column-header', 'col3')).toEqual([
       100,
       200,
       300,
     ]);
   });
-  test('cellregion-corner-header-0', () => {
-    expect(testModel.uniqueValues('corner-header', 'index')).toEqual([
+  test('cellregion-corner-header-0', async () => {
+    expect(await testModel.uniqueValues('corner-header', 'index')).toEqual([
       'A',
       'C',
       'B',
@@ -172,7 +172,7 @@ namespace Private {
       type: 'number',
       data: [1, 2, 3, 4],
     });
-    const model = new ViewBasedJSONModel(testData.data);
+    const model = new ViewBasedJSONModel({ datasource: testData.data });
     return model;
   }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ commands =
 [flake8]
 max-complexity = 22
 max-line-length = 80
-extend-ignore = E203, W503
+extend-ignore = E203, W503, U101
 noqa-require-code = true
 
 [pep8]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,7 +2259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/polling@npm:^2.1.2":
+"@lumino/polling@npm:^1 || ^2, @lumino/polling@npm:^2.1.2":
   version: 2.1.2
   resolution: "@lumino/polling@npm:2.1.2"
   dependencies:
@@ -6316,6 +6316,7 @@ __metadata:
     "@lumino/default-theme": ^1 || ^2
     "@lumino/domutils": ^1 || ^2
     "@lumino/messaging": ^1 || ^2
+    "@lumino/polling": ^1 || ^2
     "@lumino/signaling": ^1 || ^2
     "@lumino/virtualdom": ^1 || ^2
     "@lumino/widgets": ^1 || ^2


### PR DESCRIPTION
Provide a new widget `StreamingDatagrid` which lazily requests data to the back-end upon scrolling/resizing the grid. It only requests data needed to render the current viewport.

This is a very early draft for discussion, it requires more testing.

[Screencast from 2024-04-08 11-34-30.webm](https://github.com/bloomberg/ipydatagrid/assets/21197331/f547b405-26d5-42e5-8aed-51ceb697e8be)

Wish-list for this PR to be merge-able:
- [x] Filtering/sorting should be done back-end side by default for `StreamingDatagrid`, simply because the front-end does not have the whole dataset. We may want to provide the ability to do back-end filtering for the main `Datagrid` widget too, but front-end filtering should stay the default to not break current applications.
- [ ] Unit testing + Galata testing
- [x] Fix row headers
- [x] Provide a `tick` method to the Python API to allow the back-end to notify the front-end the data has changed
- [ ] Fix nested hierarchy support