### PR TITLE
Drop support for python 3.8

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,7 +36,6 @@ jobs:
           - '3.11'
           - '3.10'
           - '3.9'
-          - '3.8'
           - pypy3.9
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
 authors = [
     { name = "NumFOCUS" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Framework :: Jupyter",
   "Intended Audience :: Developers",
@@ -26,7 +26,6 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ env_list =
     py311
     py310
     py39
-    py38
     pypy3
     docs
     pkg_desc


### PR DESCRIPTION
Drop support for python 3.8 as it has reached end of life (https://devguide.python.org/versions/).